### PR TITLE
Removed argument from main function

### DIFF
--- a/src/main.kt
+++ b/src/main.kt
@@ -2,9 +2,8 @@
  * The main function.
  *
  * @author Anh Khoi Do
- * @param args  - An array of Strings the user typed at the command line.
  */
-fun main(args: Array<String>) {
+fun main() {
     demonstrateWhenStatement(3000)
     demonstrateIfStatementAfterAssignmentSymbol(true)
     demoForLoopWithList()


### PR DESCRIPTION
The argument of the main function has been unnecessary since Kotlin 1.3